### PR TITLE
removendo as videos aulas da nav bar

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -19,14 +19,14 @@
   - title: "Etc"
     url: "/tutoriais/quarto-tutorial/"
 
-- title: "Video-aulas"
-  url: "/video-aulas/"
-  side: left
-  dropdown:
-  - title: "Primeira video-aula"
-    url: "/video-aulas/primeira-video-aula/"
-  - title: "Segunda video-aula"
-    url: "/video-aulas/segunda-video-aula/"
+#- title: "Video-aulas"
+#  url: "/video-aulas/"
+#  side: left
+#  dropdown:
+#  - title: "Primeira video-aula"
+#    url: "/video-aulas/primeira-video-aula/"
+#  - title: "Segunda video-aula"
+#    url: "/video-aulas/segunda-video-aula/"
 
 - title: "Dúvidas e FAQ"
   url: "/duvidas-e-faq/"

--- a/pages/tutoriais.md
+++ b/pages/tutoriais.md
@@ -12,3 +12,9 @@ permalink: "/tutoriais/"
     <li><a href="{{ site.url }}{{ site.baseurl }}{{ tutorial.url }}">{{ tutorial.title }}</a></li>
     {% endfor %}
 </ul>
+
+<ul>
+    <h3> Veja nossos Tutoriais em <a href="/video-aulas/">Video</a></h3>
+    <li>Acesse a primeira <a href="/video-aulas/primeira-video-aula/">Video Aula</a></li>
+    <li>Acesse a Segunda <a href="/video-aulas/segunda-video-aula">Video Aula</a></li>
+</ul>


### PR DESCRIPTION
As video-aulas serão os novos tutoriais. Por isso, deve-se deletar o menu de video-aulas. mas coloquei links para acessá-las na pagina principal dos tutoriais.

Resolve #47 