### PR TITLE
arrumando o permalink

### DIFF
--- a/_presentations/manual-tecnico-dados.md
+++ b/_presentations/manual-tecnico-dados.md
@@ -5,6 +5,6 @@ header:
 title:  "Manual técnico do SMAE"
 teaser: "Manual técnico do Sistema de Monitoramento e acompanhamento Estratégico."
 breadcrumb: true
-permalink: "/documentacao-tecnica-dados/"
+permalink: "/documentacao-tecnica/dados/"
 pdf_name: documentacao-tecnica-anexo2-dados
 ---


### PR DESCRIPTION
resolve #94 

não estava abrindo a pagina pois o permalink estava errado:

estava :permalink: "/documentacao-tecnica-dados/"

em vez de :  permalink: "/documentacao-tecnica/dados/"